### PR TITLE
Configure repository for CrowdIn

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,46 @@
+#
+# Your Crowdin credentials
+#
+"project_id": ""
+"api_token": ""
+"base_path": "."
+"base_url": "https://api.crowdin.com"
+"commit_message": 'New translations: %original_file_name% (%language%)'
+"append_commit_message": false
+
+#
+# Choose file structure in Crowdin
+# e.g. true or false
+#
+"preserve_hierarchy": true
+
+#
+# Files configuration
+#
+files: [
+ {
+  #
+  # Source files filter
+  # e.g. "/resources/en/*.json"
+  #
+  "source" : "/translation/source/*.json",
+
+  #
+  # Where translations will be placed
+  # e.g. "/resources/%two_letters_code%/%original_file_name%"
+  #
+  "translation" : "/translation/dest/%locale%/%file_name%.%file_extension%",
+
+  #
+  # File type
+  # e.g. "json"
+  #
+  "type" : "json",
+
+  #
+  # The parameter "update_option" is optional. If it is not set, after the files update the translations for changed strings will be removed. Use to fix typos and for minor changes in the source strings
+  # e.g. "update_as_unapproved" or "update_without_changes"
+  #
+  "update_option" : "update_without_changes"
+ }
+]

--- a/scripts/i18n-update.ts
+++ b/scripts/i18n-update.ts
@@ -6,6 +6,7 @@ import colors = require('colors/safe')
 
 const baseDir = 'tmp/translations'
 const i18nBaseDir = '../www/i18n'
+const mobileSourceDir = '../translation/dest/'
 const unzipMaxBufferSize = 1024 * 1024 * 10 // Set maxbuffer to 10MB to avoid errors when default 1MB used
 
 const modules = ['site', 'study', 'arena', 'perfStat', 'preferences', 'settings', 'search', 'team', 'tfa', 'puzzle']
@@ -41,6 +42,14 @@ async function main() {
         } catch (e) {
           console.error(e)
         }
+      }
+    }
+
+    const mobileTranslations = loadMobileTranslations()
+    for (const locale in mobileTranslations) {
+      everything[locale] = {
+        ...everything[locale],
+        ...mobileTranslations[locale],
       }
     }
 
@@ -134,4 +143,30 @@ async function loadXml(locales: readonly string[], section: string): Promise<Rec
   return sectionXml
 }
 
+function loadMobileTranslations(): Map<string, StringMap> {
+  const localeMap = new Map()
+
+  for (const locale of readdirSync(mobileSourceDir)) {
+    localeMap[locale] = loadMobileTranslationsForLocale(locale)
+  }
+
+  return localeMap
+}
+
+function loadMobileTranslationsForLocale(locale: string): Record<string, string> {
+  let translationMap = {}
+  const localeDir = `${mobileSourceDir}/${locale}`
+
+  for (const file of readdirSync(localeDir)) {
+    const data = JSON.parse(readFileSync(`${localeDir}/${file}`).toString())
+    translationMap = {
+      ...translationMap,
+      ...data,
+    }
+  }
+  
+  return translationMap
+}
+
 main()
+

--- a/translation/source/mobile-misc.json
+++ b/translation/source/mobile-misc.json
@@ -1,0 +1,17 @@
+{
+  "apiUnsupported": "Your version of lichess app is too old! Please upgrade for free to the latest version.",
+  "apiDeprecated": "Upgrade for free to the latest lichess app! Support for this version will be dropped on %s.",
+  "resourceNotFoundError": "Resource not found.",
+  "lichessIsUnavailableError": "lichess.org is temporarily down for maintenance.",
+  "lichessIsUnreachable": "lichess.org is unreachable.",
+  "mustSignInToJoin": "You must sign in to join it.",
+  "playerisInvitingYou": "%s is inviting you",
+  "toATypeGame": "To a %s game",
+  "unsupportedVariant": "Variant %s is not supported in this version",
+  "notesSynchronizationHasFailed": "Notes synchronization with lichess has failed, please try later.",
+  "returnToHome": "Return to home",
+  "localEvalCaution": "Caution: intensive usage will drain battery.",
+  "incorrectThreefoldClaim": "Incorrect threefold repetition claim.",
+  "vibrateOnGameEvents": "Vibrate on game events",
+  "offline": "Offline"
+}


### PR DESCRIPTION
This PR sets up configuration such that this repo can be added to the lichess CrowdIn project.

Once this PR is merged, a CrowdIn administrator can add this repo, selecting the `master` branch as the source branch and maybe `i18n-master` (or whatever name they want) as the dest branch. Then, any changes in JSON files in `translation/source/*.json` will be automatically imported into the CrowdIn project.

As strings are translated, CrowdIn will automatically commit changes into `translation/dest/<locale>/<filename>.json` opn the `i18n-master` branch. When we're ready to bring said translations back into the `master` branch, we can create a merge PR.

Then, we run `npm run i18n-update`. This will download and unpack requested `lila` translation modules as before, but this time it will also add all mobile-specific CrowdIn strings (at `translation/dest/<locale>/<filename>.json`).